### PR TITLE
Refactor dozens of minor warnings

### DIFF
--- a/addons/turgys-behavior-tree/BehaviorTree/BehaviorTree.gd
+++ b/addons/turgys-behavior-tree/BehaviorTree/BehaviorTree.gd
@@ -48,6 +48,7 @@ func _construct():
 	var fromNode;
 	var toNode;
 	var fromSlot
+	#warning-ignore:unused_variable
 	var toSlot
 	all_nodes.clear()
 	for connection in all_connections:

--- a/addons/turgys-behavior-tree/BehaviorTree/Classes/repeater.gd
+++ b/addons/turgys-behavior-tree/BehaviorTree/Classes/repeater.gd
@@ -19,7 +19,7 @@ func _tick():
 	pass
 
 var retval = 0
-func _process(delta):
+func _process(_delta):
 	if begin:
 		if retval != -1:
 			retval=-1;

--- a/addons/turgys-behavior-tree/BehaviorTree/Classes/succeeder.gd
+++ b/addons/turgys-behavior-tree/BehaviorTree/Classes/succeeder.gd
@@ -12,6 +12,7 @@ func _tick():
 	if child==null:
 		push_error("Succeeder doesn't have a child");
 		return
+	#warning-ignore:unused_variable
 	var retval = child._tick()
 	return OK;
 	pass

--- a/addons/turgys-behavior-tree/BehaviorTree/Templates/action.gd
+++ b/addons/turgys-behavior-tree/BehaviorTree/Templates/action.gd
@@ -1,7 +1,7 @@
 extends Node
 
 
-static func _tick(logicRoot,BehaviorTree,Blackboard):
+static func _tick(_logicRoot,_BehaviorTree,_Blackboard):
 	return OK;
 
 

--- a/addons/turgys-behavior-tree/GraphEditor/Nodes/Action.gd
+++ b/addons/turgys-behavior-tree/GraphEditor/Nodes/Action.gd
@@ -2,7 +2,9 @@ tool
 extends GraphNode
 
 signal delete_node(node)
+#warning-ignore:unused_class_variable
 var color = Color(0.8,0.4,0.8)
+#warning-ignore:unused_class_variable
 var tag = "action"
 export(GDScript) var actionscript setget set_actionscript;
 var delete_mode = false setget set_delete_mode;
@@ -105,6 +107,7 @@ func _on_Action_resize_request(new_minsize):
 	self.rect_min_size = Vector2(min(new_minsize.x,truemin_x),min(new_minsize.y,truemin_y))
 	pass # Replace with function body.
 
+#warning-ignore:unused_class_variable
 var mouse_is_on = false;
 func _on_Name_gui_input(event):
 	if event is InputEventMouseButton:

--- a/addons/turgys-behavior-tree/GraphEditor/Nodes/Condition.gd
+++ b/addons/turgys-behavior-tree/GraphEditor/Nodes/Condition.gd
@@ -2,7 +2,9 @@ tool
 extends GraphNode
 
 signal delete_node(node)
+#warning-ignore:unused_class_variable
 var color = Color(0.8,0.4,0.8)
+#warning-ignore:unused_class_variable
 var tag = "condition"
 export(Script) var actionscript = null setget set_actionscript;
 var delete_mode = false setget set_delete_mode;
@@ -109,6 +111,7 @@ func _on_Condition_resize_request(new_minsize):
 	self.rect_min_size = Vector2(min(new_minsize.x,truemin_x),min(new_minsize.y,truemin_y))
 	pass # Replace with function body.
 
+#warning-ignore:unused_class_variable
 var mouse_is_on = false;
 func _on_Name_gui_input(event):
 	if event is InputEventMouseButton:

--- a/addons/turgys-behavior-tree/GraphEditor/Nodes/Inverter.gd
+++ b/addons/turgys-behavior-tree/GraphEditor/Nodes/Inverter.gd
@@ -2,9 +2,13 @@ tool
 extends GraphNode
 
 signal delete_node(node)
+#warning-ignore:unused_class_variable
 var color = Color(0.8,0.4,0.8)
+#warning-ignore:unused_class_variable
 var tag = "inverter"
+#warning-ignore:unused_class_variable
 var slot_counter = 0;
+#warning-ignore:unused_class_variable
 var slot_array = [];
 
 func _ready():

--- a/addons/turgys-behavior-tree/GraphEditor/Nodes/RepeatUntilFail.gd
+++ b/addons/turgys-behavior-tree/GraphEditor/Nodes/RepeatUntilFail.gd
@@ -2,9 +2,13 @@ tool
 extends GraphNode
 
 signal delete_node(node)
+#warning-ignore:unused_class_variable
 var color = Color(0.8,0.4,0.8)
+#warning-ignore:unused_class_variable
 var tag = "repeatuntilfail"
+#warning-ignore:unused_class_variable
 var slot_counter = 0;
+#warning-ignore:unused_class_variable
 var slot_array = [];
 
 func _ready():

--- a/addons/turgys-behavior-tree/GraphEditor/Nodes/Repeater.gd
+++ b/addons/turgys-behavior-tree/GraphEditor/Nodes/Repeater.gd
@@ -2,9 +2,13 @@ tool
 extends GraphNode
 
 signal delete_node(node)
+#warning-ignore:unused_class_variable
 var color = Color(0.8,0.4,0.8)
+#warning-ignore:unused_class_variable
 var tag = "repeater"
+#warning-ignore:unused_class_variable
 var slot_counter = 0;
+#warning-ignore:unused_class_variable
 var slot_array = [];
 
 func _ready():

--- a/addons/turgys-behavior-tree/GraphEditor/Nodes/Root.gd
+++ b/addons/turgys-behavior-tree/GraphEditor/Nodes/Root.gd
@@ -2,8 +2,11 @@ tool
 extends GraphNode
 
 signal delete_node(node)
+#warning-ignore:unused_class_variable
 var tag = "root"
+#warning-ignore:unused_class_variable
 var slot_counter = 0;
+#warning-ignore:unused_class_variable
 var slot_array = [];
 
 func _ready():

--- a/addons/turgys-behavior-tree/GraphEditor/Nodes/Selector.gd
+++ b/addons/turgys-behavior-tree/GraphEditor/Nodes/Selector.gd
@@ -3,6 +3,7 @@ extends GraphNode
 
 signal delete_node(node)
 var color = Color("1e8ed8")
+#warning-ignore:unused_class_variable
 var tag = "selector"
 var label = preload("res://addons/turgys-behavior-tree/GraphEditor/Nodes/SequenceLabel.tscn")
 export var slot_counter = 1
@@ -20,11 +21,11 @@ func _ready():
 	for s in get_children():
 		if s != add:
 			add_child_below_node(s,add)
-func _new_right_connection(from,from_slot,to,to_slot):
+func _new_right_connection(_from,from_slot,to,to_slot):
 	connections[self.name][String(from_slot+1)] = [to,to_slot];
 	pass
 
-func _remove_right_connection(from,from_slot,to,to_slot):
+func _remove_right_connection(_from,from_slot,_to,_to_slot):
 	connections[self.name][String(from_slot+1)] = []
 	pass
 
@@ -84,6 +85,7 @@ func _update_connections():
 
 func _delete_label(label):
 	var ID = label.ID
+	#warning-ignore:unused_variable
 	var stID = String(ID)
 	label.queue_free()
 	#_delete_connections()

--- a/addons/turgys-behavior-tree/GraphEditor/Nodes/Sequence.gd
+++ b/addons/turgys-behavior-tree/GraphEditor/Nodes/Sequence.gd
@@ -3,6 +3,7 @@ extends GraphNode
 
 signal delete_node(node)
 var color = Color("1e8ed8")
+#warning-ignore:unused_class_variable
 var tag = "sequence"
 var label = preload("res://addons/turgys-behavior-tree/GraphEditor/Nodes/SequenceLabel.tscn")
 export var slot_counter = 1
@@ -20,11 +21,11 @@ func _ready():
 	for s in get_children():
 		if s != add:
 			add_child_below_node(s,add)
-func _new_right_connection(from,from_slot,to,to_slot):
+func _new_right_connection(_from,from_slot,to,to_slot):
 	connections[self.name][String(from_slot+1)] = [to,to_slot];
 	pass
 
-func _remove_right_connection(from,from_slot,to,to_slot):
+func _remove_right_connection(_from,from_slot,_to,_to_slot):
 	connections[self.name][String(from_slot+1)] = []
 	pass
 
@@ -84,6 +85,7 @@ func _update_connections():
 
 func _delete_label(label):
 	var ID = label.ID
+	#warning-ignore:unused_variable
 	var stID = String(ID)
 	label.queue_free()
 	#_delete_connections()

--- a/addons/turgys-behavior-tree/GraphEditor/Nodes/SequenceLabel.gd
+++ b/addons/turgys-behavior-tree/GraphEditor/Nodes/SequenceLabel.gd
@@ -9,6 +9,7 @@ func _setID(val):
 	self.text = String(ID)+"."
 
 func _ready():
+	#warning-ignore:return_value_discarded
 	self.connect("delete_me",get_parent(),"_delete_label")
 func _on_TextureButton_mouse_entered():
 	$Delete.visible = true;

--- a/addons/turgys-behavior-tree/GraphEditor/Nodes/Succeeder.gd
+++ b/addons/turgys-behavior-tree/GraphEditor/Nodes/Succeeder.gd
@@ -2,9 +2,13 @@ tool
 extends GraphNode
 
 signal delete_node(node)
+#warning-ignore:unused_class_variable
 var color = Color(0.8,0.4,0.8)
+#warning-ignore:unused_class_variable
 var tag = "succeeder"
+#warning-ignore:unused_class_variable
 var slot_counter = 0;
+#warning-ignore:unused_class_variable
 var slot_array = [];
 
 func _ready():

--- a/addons/turgys-behavior-tree/GraphEditor/VisualEditor.gd
+++ b/addons/turgys-behavior-tree/GraphEditor/VisualEditor.gd
@@ -1,9 +1,12 @@
 tool
 extends GraphEdit
+#warning-ignore:unused_class_variable
 var folder;
 var behavior_tree;
+#warning-ignore:unused_class_variable
 var editorinterface;
 signal request_variable_update(obj)
+#warning-ignore:unused_class_variable
 export(Array) var all_connections
 export(Dictionary) var total_made = {
 	"Root": 0,
@@ -27,6 +30,7 @@ func _ready():
 	_update_menu_button()
 	emit_signal("request_variable_update",self,behavior_tree)
 	for conn in all_connections:
+		#warning-ignore:return_value_discarded
 		connect_node(conn[0],conn[1],conn[2],conn[3])
 	OS.set_low_processor_usage_mode(true);
 	add_valid_left_disconnect_type(0);
@@ -48,6 +52,7 @@ func _on_GraphEdit_connection_request(from, from_slot, to, to_slot):
 		get_node(from)._new_right_connection(from,from_slot,to,to_slot)
 	if get_node(from).has_method("_new_left_connection"):
 		get_node(to)._new_left_connection(from,from_slot,to,to_slot)
+	#warning-ignore:return_value_discarded
 	connect_node(from,from_slot,to, to_slot);
 	pass # Replace with function body.
 


### PR DESCRIPTION
The editor was outputing dozens of warnings of the type "unused variable", "discarded return value"... etc
If the output console gets flooded with warnings then the editor starts to clear them automatically potentially hiding important errors or warnings.

Its just a minor variable names refactor and some comments to clear specific warnings